### PR TITLE
Avoid .AppleDouble folders and very tiny files that are probably not real

### DIFF
--- a/player.html
+++ b/player.html
@@ -219,7 +219,19 @@ background-image: -moz-linear-gradient(
         var mp3 = canPlay('audio/mpeg;'), ogg = canPlay('audio/ogg; codecs="vorbis"');
         for(var i = 0; i < files.length; i++){
           var file = files[i];
-          
+	  
+	  var path = file.webkitRelativePath || file.mozFullPath || file.fileName;
+          if (path.indexOf('.AppleDouble') != -1) {
+		// Meta-data folder on Apple file systems, skip
+		continue;
+          }         
+	  var size = file.size || file.fileSize || 4096;
+	  if(size < 4095) { 
+		// Most probably not a real MP3
+		console.log(path);
+		continue;
+	  }
+ 
           if(file.fileName.indexOf('mp3') != -1){ //only does mp3 for now
             if(mp3){
               queue.push(file);


### PR DESCRIPTION
Avoid .AppleDouble folders and very tiny files that are probably not real MP3s

On a network share which is also accessed by Mac computers I seem to get these .AppleDouble folders with 1k files mirroring the parent folder - so for instance in:

```
  MyArtist/MyAlbum/
     01-song.mp3
     02-favourite.mp3
     .AppleDouble/
        01-song.mp3
        02-favourite.mp3
```

These metadata files are not real MP3s, they just have such a filename - and would appear as being part of the album .AppleDouble in the interface. 

This patch attempts to skip these metadata files by first inspecting the path (which is not always available) - secondly to ignore any files which are 4095 bytes or less in size.

I've not been able to fully test this beyond console-logging as 'antimatter15:master' does not work properly locally using file:///...player.html  using Chrome 11.0.696.16/Win7/x64.
